### PR TITLE
cmd: add pem encoding & headers

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -269,18 +269,14 @@ func RecvMSG(cmd *cobra.Command, args []string) {
 	}
 
 	buff := bytes.NewBuffer([]byte{})
-	// copy decryption to standard output
 	_, err = io.Copy(buff, rc)
-
 	block, _ := pem.Decode(<-lib.DecodeHex(buff.Bytes()))
-
 	if block == nil {
 		log.Println("err decoing pem block")
 		return
 	}
 
 	os.Stdout.WriteString("\n- - -")
-	// decode hex one last time to get original message
 	for header, val := range block.Headers {
 		os.Stdout.WriteString(fmt.Sprintf("\n%s: %s", header, val))
 	}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -5,25 +5,19 @@ const (
 	__USAGE string = `
 Send a (-m) message to a (-r) recipient 
 
-	$ lofi s -m "hi john" -r john
+	$ lofi -U your_username -P /path/to/secret.key s -m "hi john" -r john
 	> sent! to receive your message run:
-	> lofi r -k g5j2-0d
+	> 		lofi r -k g5j2-0d
 
 Share the receiving command with your friend,
 to decrypt the message they'll need to also pass
 in the absolute filepath to their private key.
 
-	$ lofi r -k g5j2-0d -p /path/to/my/private_key
-
+	$ lofi -U john -P /path/to/secret.key r -k g5j2-0d
+	> hi john
 The (-r) recipient must have a matching public key registered
-to participate. Age public keys are used, see age-keygen.
 
-Recursers are welcome to register a key, however, please know
-that this is for testing/fun/learning purposes only. Any misuse
-of 1o.fyi will result in immediate key-revocation. I'm cool with
-a server of mine breaking, as long as the requests that take 
-it down are filled with appropriate content. 
-
+see ./key-gen.sh && https://github.com/1o-fyi/register
 
 	`
 	__SHORT string = `
@@ -39,14 +33,9 @@ This lofi cli was made as a learning experience during
 a batch at the recurse center. 
 
 To participate you'll need to have a public key registered
-to a username.
+to a username. This is for testing/development/learning purposes only.
 
-Recursers are welcome to register a key, however, please know
-that this is for testing & learning purposes only. I trust 
-everybody will be respectful & conscious.
-
-lofi is using age keys, to register a public key 
-send it to John S over Zulip.
+see ./key-gen.sh && https://github.com/1o-fyi/register
 
 -		-		-		-		-		-
 


### PR DESCRIPTION
This adds a basic PEM encoding to messages before encrypting them & adds basic parsing of the messages for receiving. 